### PR TITLE
Fix invalid character in finance header

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -540,7 +540,7 @@ def main():
         # Cabeçalho da aba
         st.markdown("""
         <div class="tab-header">
-            �� ANÁLISE FINANCEIRA
+            💰 ANÁLISE FINANCEIRA
         </div>
         """, unsafe_allow_html=True)
         


### PR DESCRIPTION
## Summary
- fix the finance analysis tab header text

## Testing
- `python -m py_compile streamlit_app.py`
- `pip install -r requirements.txt`
- `python streamlit_app.py` *(fails: missing ScriptRunContext warnings, runs in bare mode)*

------
https://chatgpt.com/codex/tasks/task_e_6845c909b510832fb07b6b2a6136a620